### PR TITLE
Assorted auto pathing fixes

### DIFF
--- a/zebROS_ws/src/behaviors/src/auto_node.cpp
+++ b/zebROS_ws/src/behaviors/src/auto_node.cpp
@@ -102,7 +102,7 @@ void publishAutoState(ros::NodeHandle &nh)
 
     //publish
 	ros::Rate r(10); //TODO config
-	ros::Publisher state_pub = nh.advertise<behavior_actions::AutoState>("auto_state", 1);
+	ros::Publisher state_pub = nh.advertise<behavior_actions::AutoState>("auto_state", 1, true);
 
 	publish_autostate = true;
 	while(publish_autostate) {
@@ -113,6 +113,7 @@ void publishAutoState(ros::NodeHandle &nh)
 	}
 	// Force one last message to go out before exiting
 	doPublishAutostate(state_pub);
+	r.sleep();
 }
 
 
@@ -134,6 +135,10 @@ void waitForActionlibServer(T &action_client, double timeout, const std::string 
 			ROS_ERROR_STREAM("Auto node - " << activity << " got preempted");
 			auto_stopped = true;
 		}
+		else if(state == "ABORTED") {
+			ROS_ERROR_STREAM("Auto node - " << activity << " was aborted / rejected");
+			auto_stopped = true;
+		}
 		//check timeout - note: have to do this before checking if state is SUCCEEDED since timeouts are reported as SUCCEEDED
 		else if (ros::Time::now().toSec() - request_time > timeout || //timeout from what this file says
 				(state == "SUCCEEDED" && !action_client.getResult()->success)) //server times out by itself
@@ -143,9 +148,11 @@ void waitForActionlibServer(T &action_client, double timeout, const std::string 
 			action_client.cancelGoalsAtAndBeforeTime(ros::Time::now());
 		}
 		else if (state == "SUCCEEDED") { //must have succeeded since we already checked timeout possibility
+			ROS_WARN_STREAM("Auto node - " << activity << " succeeded");
 			break; //stop waiting
 		}
 		else if (auto_stopped){
+			ROS_WARN_STREAM("Auto node - auto_stopped set");
 			action_client.cancelGoalsAtAndBeforeTime(ros::Time::now());
 		}
 		else { //if didn't succeed and nothing went wrong, keep waiting
@@ -371,7 +378,7 @@ int main(int argc, char** argv)
 		}
 	}
 
-	shutdownNode(DONE, auto_stopped? "Auto node - Autonomous actions stopped before completion" : "Auto node - Autonomous actions completed!");
+	shutdownNode(DONE, auto_stopped ? "Auto node - Autonomous actions stopped before completion" : "Auto node - Autonomous actions completed!");
 	return 0;
 }
 

--- a/zebROS_ws/src/path_follower/src/path_follower_server.cpp
+++ b/zebROS_ws/src/path_follower/src/path_follower_server.cpp
@@ -188,6 +188,11 @@ class PathAction
 			if (!spline_gen_cli_.call(spline_gen_srv))
 			{
 				ROS_ERROR_STREAM("Can't call spline gen service in path_follower_server");
+				//log result and set actionlib server state appropriately
+				path_follower_msgs::PathResult result;
+				result.timed_out = false;
+				result.success = false;
+				as_.setAborted(result);
 				return;
 			}
 			const size_t num_waypoints = spline_gen_srv.response.path.poses.size();


### PR DESCRIPTION
Latch auto state messages - prevents race condition where last message
    might not be seen by other nodes
Return a better actionlib state if path gen fails in path gen server,
       process this message in auto_node