### PR TITLE
2 swerve drive controller updates

### DIFF
--- a/zebROS_ws/src/talon_swerve_drive_controller/include/talon_swerve_drive_controller/swerve_drive_controller.h
+++ b/zebROS_ws/src/talon_swerve_drive_controller/include/talon_swerve_drive_controller/swerve_drive_controller.h
@@ -118,11 +118,12 @@ class TalonSwerveDriveController
 	private:
 		int num_profile_slots_;
 
-		Eigen::MatrixX2d new_wheel_pos_;
-		std::array<double, WHEELCOUNT> last_wheel_rot_;	//
-
-		Eigen::Vector2d neg_wheel_centroid_;
 		bool comp_odom_;
+		Eigen::Matrix2Xd wheel_pos_;
+		Eigen::Vector2d neg_wheel_centroid_;
+		std::array<double, WHEELCOUNT> last_wheel_rot_;	    // used for odom calcs
+		std::array<double, WHEELCOUNT> last_wheel_angle_;	//
+		double angle_midpoint(double start_angle, double end_angle) const;
 
 		std::string name_;
 
@@ -349,9 +350,8 @@ class TalonSwerveDriveController
 		Eigen::Affine2d init_odom_to_base_;  // Initial odometry to base frame transform
 		Eigen::Affine2d odom_to_base_;       // Odometry to base frame transform
 		Eigen::Affine2d odom_rigid_transf_;
-		Eigen::Matrix2Xd wheel_pos_;
 
-		ros::Publisher profile_queue_num;
+		realtime_tools::RealtimePublisher<std_msgs::UInt16> profile_queue_num_;
 
 		realtime_tools::RealtimePublisher<nav_msgs::Odometry> odom_pub_;
 		tf2_ros::TransformBroadcaster odom_tf_;


### PR DESCRIPTION
- for odom, use midpoint of start&end wheel steering angle to
extrapolate motion rather than just the endpoint. Should improve
accuracy when the steering motors are moving and be the same when we
aren't rotating
- Fix a case of using a regular publisher inside the realtime
update() function - changed to a realtime (nonblocking) publisher
instead.

Need to test on robot before merging