### PR TITLE
Optimize rotation velocity at intermediate pathgen waypoints

### DIFF
--- a/zebROS_ws/src/base_trajectory/include/base_trajectory/opt_params.h
+++ b/zebROS_ws/src/base_trajectory/include/base_trajectory/opt_params.h
@@ -13,13 +13,19 @@ struct OptParams
 	double maxOffX_{0};
 	double minOffY_{0};
 	double maxOffY_{0};
-	double length_{0};       // These control the
+	double length_{0};       // These control the curveature vs. velocity at waypoints
 	double minLength_{-std::numeric_limits<double>::max()};
 	double maxLength_{std::numeric_limits<double>::max()};
-	double lengthScale_{0.75}; // curveature vs. velocity at waypoints
+	double lengthScale_{0.75};
 	double minLengthScale_{-std::numeric_limits<double>::max()};
 	double maxLengthScale_{std::numeric_limits<double>::max()};
-	double deltaVMagnitude_{0};
+	double minRotLength_{-std::numeric_limits<double>::max()};
+	double maxRotLength_{std::numeric_limits<double>::max()};
+	double rotLength_{0};
+	double rotLengthScale_{0.75};
+	double minRotLengthScale_{-std::numeric_limits<double>::max()};
+	double maxRotLengthScale_{std::numeric_limits<double>::max()};
+	double deltaVMagnitude_{0}; // Last waypoint velocity vector
 	double deltaVDirection_{0};
 	double minDeltaVMagnitude_{0};
 	double maxDeltaVMagnitude_{0};

--- a/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
+++ b/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
@@ -176,6 +176,8 @@ bool generateSpline(      std::vector<trajectory_msgs::JointTrajectoryPoint> poi
 	double prevLength = hypot(points[1].positions[0] - points[0].positions[0],
 							  points[1].positions[1] - points[0].positions[1]);
 
+	double prevRotLength = points[1].positions[2] - points[0].positions[2];
+
 	for (size_t i = 1; i < (points.size() - 1); i++)
 	{
 		const auto &mi   = points[i].positions;
@@ -190,12 +192,14 @@ bool generateSpline(      std::vector<trajectory_msgs::JointTrajectoryPoint> poi
 		const double angle = angles::normalize_angle_positive(prevAngle + deltaAngle / 2.0);
 
 		const double currLength = hypot(mip1[0] - mi[0], mip1[1] - mi[1]);
+		const double currRotLength = mip1[2] - mi[2];
 
 		// Adding a scaling factor here controls the velocity
 		// at the waypoints.  Bigger than 1 ==> curvier path with
 		// higher speeds.  Less than 1 ==> tigher turns to stay
 		// closer to straight paths.
 		const double length = std::min(prevLength, currLength) * optParams[i].lengthScale_ + optParams[i].length_;
+		const double rotLength = (prevRotLength + currRotLength) / 2.0 * optParams[i].rotLengthScale_ + optParams[i].rotLength_;
 
 		// Don't overwrite requested input velocities
 		if (points[i].velocities.size() == 0)
@@ -203,7 +207,7 @@ bool generateSpline(      std::vector<trajectory_msgs::JointTrajectoryPoint> poi
 		if (points[i].velocities.size() == 1)
 			points[i].velocities.push_back(length * sin(angle)); // y
 		if (points[i].velocities.size() == 2)
-			points[i].velocities.push_back(fabs(mip1[2] - mi[2])); // theta TODO : Check me
+			points[i].velocities.push_back(rotLength); // theta TODO : Check me
 														// Need a length and length scale for this case?
 
 		points[i].velocities[0] += optParams[i].deltaVMagnitude_ * cos(angle + optParams[i].deltaVDirection_);

--- a/zebROS_ws/src/base_trajectory/src/opt_params.cpp
+++ b/zebROS_ws/src/base_trajectory/src/opt_params.cpp
@@ -10,6 +10,7 @@ OptParams::OptParams(double minOffX, double maxOffX, double minOffY, double maxO
 {
 }
 
+// Use to enable optimization of endpoint velocity vector
 void OptParams::setDeltaV(double minMagnitude, double maxMagnitude, double minDirection, double maxDirection)
 {
 	minDeltaVMagnitude_ = minMagnitude;
@@ -18,12 +19,20 @@ void OptParams::setDeltaV(double minMagnitude, double maxMagnitude, double minDi
 	maxDeltaVDirection_ = maxDirection;
 }
 
+// Force length var ranges to be +/- 0 from
+// the current value. Used to disable optimization
+// of these vars for start and end points since they
+// don't apply
 void OptParams::clearLengthLimits(void)
 {
 	minLength_ = length_;
 	maxLength_ = length_;
 	minLengthScale_ = lengthScale_;
 	maxLengthScale_ = lengthScale_;
+	minRotLength_ = rotLength_;
+	maxRotLength_ = rotLength_;
+	minRotLengthScale_ = rotLengthScale_;
+	maxRotLengthScale_ = rotLengthScale_;
 }
 
 bool OptParams::IsAtMax(size_t index) const
@@ -52,6 +61,14 @@ bool OptParams::IsAtMax(size_t index) const
 	{
 		return deltaVDirection_ >= maxDeltaVDirection_;
 	}
+	if (index == 6) // length_
+	{
+		return rotLength_ >= maxRotLength_;
+	}
+	if (index == 7) // lengthScale_
+	{
+		return rotLengthScale_ >= maxRotLengthScale_;
+	}
 
 	throw std::out_of_range ("out of range in OptParams IncrementVariable");
 	return false;
@@ -68,11 +85,11 @@ bool OptParams::IncrementVariable(size_t index, double value)
 	{
 		return IncrementHelper(posY_, value, minOffY_, maxOffY_);
 	}
-	if (index == 2)
+	if (index == 2) // length_
 	{
 		return IncrementHelper(length_, value, minLength_, maxLength_);
 	}
-	if (index == 3)
+	if (index == 3) // lengthScale_
 	{
 		return IncrementHelper(lengthScale_, value, minLengthScale_, maxLengthScale_);
 	}
@@ -84,6 +101,14 @@ bool OptParams::IncrementVariable(size_t index, double value)
 	{
 		return IncrementHelper(deltaVDirection_, value, minDeltaVDirection_, maxDeltaVDirection_);
 	}
+	if (index == 6) // rotLength_
+	{
+		return IncrementHelper(rotLength_, value, minRotLength_, maxRotLength_);
+	}
+	if (index == 7) // rotLengthScale_
+	{
+		return IncrementHelper(rotLengthScale_, value, minRotLengthScale_, maxRotLengthScale_);
+	}
 	throw std::out_of_range ("out of range in OptParams IncrementVariable");
 	return false;
 }
@@ -94,7 +119,7 @@ bool OptParams::IncrementVariable(size_t index, double value)
 // in there into a simple for() loop
 size_t OptParams::size(void) const
 {
-	return 6;
+	return 8;
 }
 
 bool OptParams::IncrementHelper(double &var, double value, double minOff, double maxOff)
@@ -136,7 +161,17 @@ std::ostream& operator<< (std::ostream& stream, const OptParams &optParams)
 	stream << " minOffY_:" << optParams.minOffY_;
 	stream << " maxOffY_:" << optParams.maxOffY_;
 	stream << " length_:" << optParams.length_;
+	stream << " maxLength_:" << optParams.maxLength_;
+	stream << " minLength_:" << optParams.minLength_;
 	stream << " lengthScale_:" << optParams.lengthScale_;
+	stream << " maxLengthScale_:" << optParams.maxLengthScale_;
+	stream << " minLengthScale_:" << optParams.minLengthScale_;
+	stream << " rotLength_:" << optParams.length_;
+	stream << " maxRotLength_:" << optParams.maxRotLength_;
+	stream << " minRotLength_:" << optParams.minRotLength_;
+	stream << " rotLengthScale_:" << optParams.lengthScale_;
+	stream << " maxRotLengthScale_:" << optParams.maxRotLengthScale_;
+	stream << " minRotLengthScale_:" << optParams.minRotLengthScale_;
 	stream << " deltaVMagnitude_:" << optParams.deltaVMagnitude_;
 	stream << " maxDeltaVMagnitude_:" << optParams.maxDeltaVMagnitude_;
 	stream << " minDeltaVMagnitude_:" << optParams.minDeltaVMagnitude_;


### PR DESCRIPTION
Starting guess is difference in change in rotation between prev and curr, curr and next waypoint
Then add multiplier and addition terms as optimization variables