### PR TITLE
Moved extra arguments from ./docker-run to the docker run command

### DIFF
--- a/docker/docker-run
+++ b/docker/docker-run
@@ -8,4 +8,4 @@ set -o pipefail
 
 docker run "$@" -it --net=host -v  /tmp/.X11-unix:/tmp/.X11-unix \
  -v $HOME/2020Offseason:/home/ubuntu/2020Offseason \
- -e DISPLAY=$DISPLAY --privileged --user ubuntu frc900/zebros-2021-dev:latest /bin/bash 
+ -e DISPLAY=$DISPLAY --privileged --user ubuntu frc900/zebros-2021-dev:latest /bin/bash

--- a/docker/docker-run
+++ b/docker/docker-run
@@ -6,6 +6,6 @@ dev_dir="$( dirname "$dev_dir" )"
 set -e
 set -o pipefail
 
-docker run -it --net=host -v  /tmp/.X11-unix:/tmp/.X11-unix \
+docker run "$@" -it --net=host -v  /tmp/.X11-unix:/tmp/.X11-unix \
  -v $HOME/2020Offseason:/home/ubuntu/2020Offseason \
- -e DISPLAY=$DISPLAY --privileged --user ubuntu frc900/zebros-2021-dev:latest /bin/bash
+ -e DISPLAY=$DISPLAY --privileged --user ubuntu frc900/zebros-2021-dev:latest /bin/bash 


### PR DESCRIPTION
This way ./docker-run --rm will remove the docker container after it exits, and other arguments can be passed too.