### PR TITLE
Replace pf_pose message with PoseWithCovarianceStamped

### DIFF
--- a/zebROS_ws/src/pf_localization/CMakeLists.txt
+++ b/zebROS_ws/src/pf_localization/CMakeLists.txt
@@ -7,6 +7,7 @@ include("../cmake_modules/CMakeOpt.cmake")
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  angles
   ar_track_alvar_msgs
   rospy
   roscpp

--- a/zebROS_ws/src/pf_localization/include/pf_localization/particle_filter.hpp
+++ b/zebROS_ws/src/pf_localization/include/pf_localization/particle_filter.hpp
@@ -5,7 +5,7 @@
 #include <random>
 #include "particle.hpp"
 #include "world_model.hpp"
-#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/PoseWithCovariance.h>
 
 #define CHECK_PARTICLES(o) o->check_particles(__FILE__, __LINE__);
 class ParticleFilter {
@@ -24,7 +24,7 @@ public:
   ParticleFilter(const WorldModel& w,
                  double x_min, double x_max, double y_min, double y_max,
                  double ns, double rs, size_t n);
-  geometry_msgs::PoseWithCovarianceStamped predict();
+  geometry_msgs::PoseWithCovariance predict();
   void noise_rot();
   void noise_pos();
   bool motion_update(double delta_x, double delta_y, double delta_rot);

--- a/zebROS_ws/src/pf_localization/include/pf_localization/particle_filter.hpp
+++ b/zebROS_ws/src/pf_localization/include/pf_localization/particle_filter.hpp
@@ -5,6 +5,7 @@
 #include <random>
 #include "particle.hpp"
 #include "world_model.hpp"
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
 
 #define CHECK_PARTICLES(o) o->check_particles(__FILE__, __LINE__);
 class ParticleFilter {
@@ -23,7 +24,7 @@ public:
   ParticleFilter(const WorldModel& w,
                  double x_min, double x_max, double y_min, double y_max,
                  double ns, double rs, size_t n);
-  Particle predict();
+  geometry_msgs::PoseWithCovarianceStamped predict();
   void noise_rot();
   void noise_pos();
   bool motion_update(double delta_x, double delta_y, double delta_rot);

--- a/zebROS_ws/src/pf_localization/src/particle_filter.cpp
+++ b/zebROS_ws/src/pf_localization/src/particle_filter.cpp
@@ -2,7 +2,7 @@
 
 #include "pf_localization/particle_filter.hpp"
 #include "pf_localization/world_model.hpp"
-#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/PoseWithCovariance.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <cmath>
 #include <ros/console.h>
@@ -107,7 +107,7 @@ void ParticleFilter::resample() {
   normalize();
 }
 
-geometry_msgs::PoseWithCovarianceStamped ParticleFilter::predict() {
+geometry_msgs::PoseWithCovariance ParticleFilter::predict() {
   double weight = 0;
   double x = 0;
   double y = 0;
@@ -115,18 +115,15 @@ geometry_msgs::PoseWithCovarianceStamped ParticleFilter::predict() {
   double c = 0;
 
   // Initializes all values to 0
-  float covariance[16] = {0};
+  float covariance[9] = {0};
 
   for (const Particle& p : particles_) {
-    double sin_ = sin(p.rot_);
-    double cos_ = cos(p.rot_);
-
     // Update covariance matrix
-    double variables[4] = {p.x_, p.y_, sin_, cos_};
+    double variables[3] = {p.x_, p.y_, p.rot_};
 
-    for(int i = 0; i < 4; i++) {
-      for(int j = 0; j < 4; j++) {
-        int index = i * 4 + j;
+    for(int i = 0; i < 3; i++) {
+      for(int j = 0; j < 3; j++) {
+        int index = i * 3 + j;
         // Normally, variables[i] would be subtracted by the mean of all variables[i]
         // to give the distance from the mean instead of the distance from zero.
         // We don't have the means already, so we factor out that part and do it at the end.
@@ -137,21 +134,9 @@ geometry_msgs::PoseWithCovarianceStamped ParticleFilter::predict() {
     // Add weighted values to means
     x += p.x_ * p.weight_;
     y += p.y_ * p.weight_;
-    c += cos_ * p.weight_;
-    s += sin_ * p.weight_;
+    c += cos(p.rot_) * p.weight_;
+    s += sin(p.rot_) * p.weight_;
     weight += p.weight_;
-  }
-
-  // This is where the covariances are adjusted to be measuring from the mean
-  // instead of measuring from zero. This part was factored out of the loop
-  // because we don't have the means until the end of the loop.
-  double means[4] = {x, y, s, c};
-
-  for(int i = 0; i < 4; i++) {
-    for(int j = 0; j < 4; j++) {
-      int index = i * 4 + j;
-      covariance[index] = (covariance[index] / weight) - (means[i] * means[j]);
-    }
   }
 
   // Divide by weight to get the weighted average
@@ -161,27 +146,39 @@ geometry_msgs::PoseWithCovarianceStamped ParticleFilter::predict() {
   s /= weight;
   double rot = atan2(s, c);
 
-  // Packing everything into the PoseWithCovarianceStamped
-  geometry_msgs::PoseWithCovarianceStamped pose;
-  pose.pose.pose.position.x = x;
-  pose.pose.pose.position.y = y;
-  pose.pose.pose.position.z = 0;
+  // This is where the covariances are adjusted to be measuring from the mean
+  // instead of measuring from zero. This part was factored out of the loop
+  // because we don't have the means until the end of the loop.
+  double means[3] = {x, y, rot};
+
+  for(int i = 0; i < 3; i++) {
+    for(int j = 0; j < 3; j++) {
+      int index = i * 3 + j;
+      covariance[index] = (covariance[index] / weight) - (means[i] * means[j]);
+    }
+  }
+
+  // Packing everything into PoseWithCovariance
+  geometry_msgs::PoseWithCovariance pose;
+  pose.pose.position.x = x;
+  pose.pose.position.y = y;
+  pose.pose.position.z = 0;
 
   tf2::Quaternion q;
   q.setRPY(0, 0, rot);
-  pose.pose.pose.orientation.x = q.getX();
-  pose.pose.pose.orientation.y = q.getY();
-  pose.pose.pose.orientation.z = q.getZ();
-  pose.pose.pose.orientation.w = q.getW();
+  pose.pose.orientation.x = q.getX();
+  pose.pose.orientation.y = q.getY();
+  pose.pose.orientation.z = q.getZ();
+  pose.pose.orientation.w = q.getW();
 
-  std::fill(std::begin(pose.pose.covariance), std::begin(pose.pose.covariance)+36, 1000);
-  for(int i = 0; i < 4; i++) {
-    for(int j = 0; j < 4; j++) {
-      // Offset to skip over z rotation
-      int row = i > 1 ? i + 1 : i;
-      int column = j > 1 ? j + 1 : j;
+  std::fill(std::begin(pose.covariance), std::begin(pose.covariance)+36, 1000);
+  for(int i = 0; i < 3; i++) {
+    for(int j = 0; j < 3; j++) {
+      // Offset to skip to z rotation
+      int row = i > 1 ? i + 3 : i;
+      int column = j > 1 ? j + 3 : j;
       // The matrix is 6x6
-      pose.pose.covariance[row * 6 + column] = covariance[i * 4 + j];
+      pose.covariance[row * 6 + column] = covariance[i * 3 + j];
     }
   }
 

--- a/zebROS_ws/src/pf_localization/src/pf_localization_node.cpp
+++ b/zebROS_ws/src/pf_localization/src/pf_localization_node.cpp
@@ -65,7 +65,7 @@ void publish_prediction(const ros::TimerEvent &/*event*/)
 
   predictionStamped.pose = prediction;
   predictionStamped.header.stamp = ros::Time::now();
-  predictionStamped.header.frame_id = odom_frame_id;
+  predictionStamped.header.frame_id = map_frame_id;
 
   pub.publish(predictionStamped);
 

--- a/zebROS_ws/src/pf_localization/src/pf_localization_node.cpp
+++ b/zebROS_ws/src/pf_localization/src/pf_localization_node.cpp
@@ -13,6 +13,7 @@
 #include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/PoseWithCovariance.h>
 #include <sensor_msgs/Imu.h>
 #include <iostream>
 #include <ros/ros.h>
@@ -59,17 +60,23 @@ void rotCallback(const sensor_msgs::Imu::ConstPtr& msg) {
 
 void publish_prediction(const ros::TimerEvent &/*event*/)
 {
-  const geometry_msgs::PoseWithCovarianceStamped prediction = pf->predict();
-  pub.publish(prediction);
+  const geometry_msgs::PoseWithCovariance prediction = pf->predict();
+  geometry_msgs::PoseWithCovarianceStamped predictionStamped;
+
+  predictionStamped.pose = prediction;
+  predictionStamped.header.stamp = ros::Time::now();
+  predictionStamped.header.frame_id = odom_frame_id;
+
+  pub.publish(predictionStamped);
 
   // Publish map->odom transform describing this position
-  const tf2::Quaternion q(prediction.pose.pose.orientation.x,
-    prediction.pose.pose.orientation.y,
-    prediction.pose.pose.orientation.z,
-    prediction.pose.pose.orientation.w);
+  const tf2::Quaternion q(prediction.pose.orientation.x,
+    prediction.pose.orientation.y,
+    prediction.pose.orientation.z,
+    prediction.pose.orientation.w);
 
-  tf2::Vector3 pos(prediction.pose.pose.position.x,
-    prediction.pose.pose.position.y,
+  tf2::Vector3 pos(prediction.pose.position.x,
+    prediction.pose.position.y,
     0.0);
 
   const double tmp = pos.getX() + pos.getY() + pos.getZ() + q.getX() + q.getY() + q.getZ() + q.getW();

--- a/zebROS_ws/src/pf_localization/src/pf_localization_node.cpp
+++ b/zebROS_ws/src/pf_localization/src/pf_localization_node.cpp
@@ -2,7 +2,6 @@
 #include "pf_localization/particle_filter.hpp"
 #include "pf_localization/world_model.hpp"
 #include "pf_localization/particle.hpp"
-#include "pf_localization/pf_pose.h"
 #include "pf_localization/pf_debug.h"
 #include "field_obj/Detection.h"
 
@@ -13,6 +12,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <sensor_msgs/Imu.h>
 #include <iostream>
 #include <ros/ros.h>
@@ -59,18 +59,20 @@ void rotCallback(const sensor_msgs::Imu::ConstPtr& msg) {
 
 void publish_prediction(const ros::TimerEvent &/*event*/)
 {
-  const Particle prediction = pf->predict();
-
-  // Publish message with predicted pose
-  // TODO - see if std ROS odom message is a better fit than a custom messge
-  pf_localization::pf_pose pose;
-  pose.x = prediction.x_;
-  pose.y = prediction.y_;
-  pose.rot = prediction.rot_;
-  pub.publish(pose);
+  const geometry_msgs::PoseWithCovarianceStamped prediction = pf->predict();
+  pub.publish(prediction);
 
   // Publish map->odom transform describing this position
-  const double tmp = prediction.x_ + prediction.y_ + prediction.rot_;
+  const tf2::Quaternion q(prediction.pose.pose.orientation.x,
+    prediction.pose.pose.orientation.y,
+    prediction.pose.pose.orientation.z,
+    prediction.pose.pose.orientation.w);
+
+  tf2::Vector3 pos(prediction.pose.pose.position.x,
+    prediction.pose.pose.position.y,
+    0.0);
+
+  const double tmp = pos.getX() + pos.getY() + pos.getZ() + q.getX() + q.getY() + q.getZ() + q.getW();
   if (!std::isnan(tmp) && !std::isinf(tmp))
   {
     geometry_msgs::PoseStamped odom_to_map;
@@ -80,9 +82,7 @@ void publish_prediction(const ros::TimerEvent &/*event*/)
       // leaving a map->odom transform to broadcast
       // Borrowed from similar code in
       // https://github.com/ros-planning/navigation/blob/noetic-devel/amcl/src/amcl_node.cpp
-      tf2::Quaternion q;
-      q.setRPY(0, 0, prediction.rot_);
-      tf2::Transform tmp_tf(q, tf2::Vector3(prediction.x_, prediction.y_, 0.0));
+      tf2::Transform tmp_tf(q, pos);
 
       geometry_msgs::PoseStamped baselink_to_map;
       baselink_to_map.header.frame_id = "base_link";
@@ -292,7 +292,7 @@ int main(int argc, char **argv) {
   ros::Subscriber odom_sub = nh_.subscribe(cmd_topic, 1, cmdCallback);
   ros::Subscriber goal_sub = nh_.subscribe<field_obj::Detection>(goal_pos_topic, 1, boost::bind(goalCallback, _1, false));
 
-  pub = nh_.advertise<pf_localization::pf_pose>(pub_topic, 1);
+  pub = nh_.advertise<geometry_msgs::PoseWithCovarianceStamped>(pub_topic, 1);
   pub_debug = nh_.advertise<pf_localization::pf_debug>(pub_debug_topic, 1);
 
   tfbr = std::make_unique<tf2_ros::TransformBroadcaster>();


### PR DESCRIPTION
Closes https://github.com/FRC900/prog_gen_tasks/issues/430. The covariance matrix is computed while computing the mean particle, and then a message containing the pose and the covariance matrix is published to `/predicted_pose`. I couldn't remove the pf_pose message, because an array of pf_poses gets published to `/pf_debug`.