### PR TITLE
Fixed bugs and added rotation to the game piece path server

### DIFF
--- a/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
+++ b/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
@@ -1503,6 +1503,9 @@ bool NLOPT(
 	opt.set_ftol_abs(0.05);
 	std::vector<double> x;
 	optParams.toVector(x);
+	if (x.size() == 0) {
+		return true; // use original path
+	}
 
 	double cost;
 	try

--- a/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
+++ b/zebROS_ws/src/base_trajectory/src/base_trajectory.cpp
@@ -353,6 +353,7 @@ bool generateSpline(const std::vector<trajectory_msgs::JointTrajectoryPoint> &po
 		initSplinePoints[i].time_from_start = points[i].time_from_start.toSec();
 		initSplinePoints[i].state[0].position = points[i].positions[0] + optParams[i].posX_;
 		initSplinePoints[i].state[1].position = points[i].positions[1] + optParams[i].posY_;
+		initSplinePoints[i].state[2].position = points[i].positions[2];
 		//points[i].positions[0] += optParams[i].posX_;
 		//points[i].positions[1] += optParams[i].posY_;
 	}
@@ -2192,4 +2193,3 @@ int main(int argc, char **argv)
 
 	ros::spin();
 }
-

--- a/zebROS_ws/src/behavior_actions/srv/GamePiecePickup.srv
+++ b/zebROS_ws/src/behavior_actions/srv/GamePiecePickup.srv
@@ -4,3 +4,4 @@ geometry_msgs/Pose endpoint # only x position, y position, and z rotation will b
 ---
 bool success
 string message
+nav_msgs/Path path

--- a/zebROS_ws/src/behaviors/config/game_piece_path_config.yaml
+++ b/zebROS_ws/src/behaviors/config/game_piece_path_config.yaml
@@ -1,3 +1,4 @@
 game_piece_path_gen_params:
   game_piece_frame_id: "intake"
   game_piece_intake_offsets: [0.0]
+  maximum_z: 10.0

--- a/zebROS_ws/src/behaviors/src/game_piece_path_gen.cpp
+++ b/zebROS_ws/src/behaviors/src/game_piece_path_gen.cpp
@@ -68,6 +68,7 @@ std::vector<double> gamePieceIntakeOffsets{0};
 
 bool genPath(behavior_actions::GamePiecePickup::Request &req, behavior_actions::GamePiecePickup::Response &res)
 {
+	// NOTE Endpoint is robot relative
 	res.success = false; // Default to failure
 	base_trajectory_msgs::GenerateSpline spline_gen_srv;
 

--- a/zebROS_ws/src/behaviors/src/game_piece_path_gen.cpp
+++ b/zebROS_ws/src/behaviors/src/game_piece_path_gen.cpp
@@ -104,7 +104,7 @@ bool genPath(behavior_actions::GamePiecePickup::Request &req, behavior_actions::
 	});
 
 	for (size_t i = 0; i < std::min(objects_num, objectPoints.size()); i++) { // Add object points to list of points
-		ROS_INFO_STREAM("Choosing power cell at " << objectPoints[i][0] << "," << objectPoints[i][1] << " relative to " << lastObjectDetection.header.frame_id);
+		ROS_INFO_STREAM("Choosing game piece at " << objectPoints[i][0] << "," << objectPoints[i][1] << " relative to " << lastObjectDetection.header.frame_id);
 		points.push_back(objectPoints[i]);
 	}
 

--- a/zebROS_ws/src/behaviors/src/game_piece_path_gen.cpp
+++ b/zebROS_ws/src/behaviors/src/game_piece_path_gen.cpp
@@ -78,8 +78,6 @@ bool genPath(behavior_actions::GamePiecePickup::Request &req, behavior_actions::
 
 	geometry_msgs::TransformStamped robotToMapTransform = tfBuffer->lookupTransform("map", "base_link", ros::Time(0));
 
-	ROS_INFO_STREAM("Robot location: " << robotToMapTransform.transform.translation.x << ", " << robotToMapTransform.transform.translation.y);
-
 	Line l = Line(robotToMapTransform.transform.translation.x, robotToMapTransform.transform.translation.y, req.endpoint.position.x, req.endpoint.position.y);
 
 	std::vector<std::array<double, 3>> points; // List of all points

--- a/zebROS_ws/src/behaviors/src/game_piece_path_gen.cpp
+++ b/zebROS_ws/src/behaviors/src/game_piece_path_gen.cpp
@@ -82,7 +82,8 @@ bool genPath(behavior_actions::GamePiecePickup::Request &req, behavior_actions::
 	{
 		if ((lastObjectDetection.objects[i].id == req.object_id) && (lastObjectDetection.objects[i].location.z <= maximumZ))
 		{
-			objectPoints.push_back({lastObjectDetection.objects[i].location.x, lastObjectDetection.objects[i].location.y, 0});
+			objectPoints.push_back({lastObjectDetection.objects[i].location.x, lastObjectDetection.objects[i].location.y, 0}); // TODO: set 0 to correct orientation for intake
+			// Consider atan2(deltaX/deltaY)
 		}
 	}
 
@@ -170,6 +171,7 @@ bool genPath(behavior_actions::GamePiecePickup::Request &req, behavior_actions::
 	}
 	res.success = true; // Default to failure
 	res.message = "to infinity and beyond!";
+	res.path = spline_gen_srv.response.path;
 	return true;
 }
 

--- a/zebROS_ws/src/controller_node/stage/2021PathFollower.world
+++ b/zebROS_ws/src/controller_node/stage/2021PathFollower.world
@@ -81,3 +81,6 @@ objdet_target ( pose [ -1.72  2.263 1 0 ] fiducial_return 5 color "purple")
 objdet_target ( pose [ -1.72  3.103 1 0 ] fiducial_return 3 color "orange")
 objdet_target ( pose [ 3 1 5 0 ] size [ 0.18 0.18 0.18 ] fiducial_return 900 color "yellow") # 900 = power cell
 objdet_target ( pose [ 4 2 5 0 ] size [ 0.18 0.18 0.18 ] fiducial_return 900 color "yellow") # 900 = power cell
+objdet_target ( pose [ 1 1 5 0 ] size [ 0.18 0.18 0.18 ] fiducial_return 900 color "yellow") # 900 = power cell
+objdet_target ( pose [ -1 2 5 0 ] size [ 0.18 0.18 0.18 ] fiducial_return 900 color "yellow") # 900 = power cell
+objdet_target ( pose [ -3 -3 5 0 ] size [ 0.18 0.18 0.18 ] fiducial_return 900 color "yellow") # 900 = power cell


### PR DESCRIPTION
`game_piece_path_gen.cpp` had a few bugs with selecting objects if there is a limit, so this PR fixes those. It now selects the closest game pieces to the line between the start and end point.

It also now rotates to face each game piece.